### PR TITLE
use php 7.4 for generating the release as that is the requirement of composer dependencies

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-        # Release happens only if the version number in Astra_Notices is updated.
-        - 'class-astra-notices.php'
 
 jobs:
   build:
@@ -14,6 +11,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+          tools: composer, cs2pr
 
       - name: Maybe create a tag
         run: bash bin/release.sh


### PR DESCRIPTION
Drop requirement of the tag workflow in github actions to be run only if the main file is changed
As in in cases where the deployment does not work for some other reason, it will not be re-triggered unless any change is mande to this file