### PR TITLE
Drop `v` from the tags

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -81,7 +81,7 @@ git push origin "$DEPLOY_BRANCH"
 
 # Make a release if one doesn't exist.
 if [[ $DEPLOY_AS_RELEASE = "yes" && $(git tag -l "$VERSION") != $VERSION ]]; then
-    git tag "v$VERSION"
-    git push origin "v$VERSION"
-    echo "BRAINSTORM_FORCE_RELEASE=v$VERSION" >> $GITHUB_ENV
+    git tag "$VERSION"
+    git push origin "$VERSION"
+    echo "BRAINSTORM_FORCE_RELEASE=$VERSION" >> $GITHUB_ENV
 fi


### PR DESCRIPTION
Right now we have tags with `v1.1.8`, This PR will change this to `1.1.8` so that the tags can also be pulled using composer