### PR TITLE
Avoid using singleton in the unit tests

### DIFF
--- a/tests/test-notice-visible-correct-role.php
+++ b/tests/test-notice-visible-correct-role.php
@@ -41,7 +41,8 @@ class TestNoticeVisibleForCorrectRole extends WP_UnitTestCase {
 	 * Test to verify the notice is visible to user's with given user level/capability.
 	 */
 	public function test_user_can_see_notice() {
-		$astra_notices = Astra_Notices::get_instance();
+		// Singleton is not used here as that causes the notices registered in one test to be visible in the next.
+		$astra_notices = new Astra_Notices();
 
 		Astra_Notices::add_notice(
 			array(
@@ -71,7 +72,8 @@ class TestNoticeVisibleForCorrectRole extends WP_UnitTestCase {
 	 * Test that if capability is not passed, the notice is visible only to the user's with `manage_options` cap.
 	 */
 	public function test_user_can_see_notice_without_capability() {
-		$astra_notices = Astra_Notices::get_instance();
+		// Singleton is not used here as that causes the notices registered in one test to be visible in the next.
+		$astra_notices = new Astra_Notices();
 
 		Astra_Notices::add_notice(
 			array(


### PR DESCRIPTION
If we use singleton, a notice registered from one unit test is also available in the next test as the same instance is carried forward in those tests. By initializing the class separately I am resetting the registered notices so that each test runs separately.

https://github.com/brainstormforce/astra-notices/pull/1#discussion_r676340983