### PR TITLE
Added Notice ID check for Validation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -10,7 +10,7 @@ Easily Create Admin Notices.
 **Default Parameters**
 ```PHP
 array(
-    'id'                         => '',      // Optional, Notice ID. If empty it set `astra-notices-id-<$array-index>`.
+    'id'                         => '',      // Required, Notice ID. Id can be like: `astra-notices-id-<$pluginslug>`.
     'type'                       => 'info',  // Optional, Notice type. Default `info`. Expected [info, warning, notice, error].
     'message'                    => '',      // Optional, Message.
     'show_if'                    => true,    // Optional, Show notice on custom condition. E.g. 'show_if' => if( is_admin() ) ? true, false, .

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 */
 		public static function add_notice( $args = array() ) {
 			self::$notices[] = $args;
-			if ( empty( $args['id'] ) ) { 
+			if ( ! is_array( $args ) || empty( $args['id'] ) ) {
 				return; 
    			}
 			$notice_id = $args['id']; // Notice ID.

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -138,7 +138,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 			);
 
 			// if $notice_id does not start with astra-notices-id and notice_id is not from the allowed notices, then return.
-			if ( strpos( $notice_id, 'astra-notices-id-' ) === false && array_search( $notice_id, $allowed_notices ) === false ) {
+			if ( strpos( $notice_id, 'astra-notices-id-' ) !== 0 && array_search( $notice_id, $allowed_notices ) === false ) {
 				return;
 			}
 
@@ -235,7 +235,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 				)
 			);
 
-			return ! empty( $notice ) ? $notice[0] : array();
+			return ( ! empty( $notice ) && isset( $notice[0] ) ) ? $notice[0] : array();
 		}
 
 		/**

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @var array Notices.
 		 * @since 1.0.0
 		 */
-		private static $version = '1.1.12';
+		private static $version = '1.1.13';
 
 		/**
 		 * Notices
@@ -96,6 +96,9 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 */
 		public static function add_notice( $args = array() ) {
 			self::$notices[] = $args;
+			if ( empty( $args['id'] ) ) { 
+				return; 
+   			}
 			$notice_id = $args['id']; // Notice ID.
 			$notices = get_option( 'allowed_astra_notices', array() );
 			if(array_search($notice_id, $notices) === false) { 

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -95,10 +95,10 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @return void
 		 */
 		public static function add_notice( $args = array() ) {
-			self::$notices[] = $args;
 			if ( ! is_array( $args ) || empty( $args['id'] ) ) {
-				return; 
+			    return; 
    			}
+			self::$notices[] = $args;
 			$notice_id = $args['id']; // Notice ID.
 			$notices = get_option( 'allowed_astra_notices', array() );
 			if(array_search($notice_id, $notices) === false) { 

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -95,10 +95,12 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @return void
 		 */
 		public static function add_notice( $args = array() ) {
-			if ( ! is_array( $args ) || empty( $args['id'] ) ) {
-			    return; 
-   			}
 			self::$notices[] = $args;
+
+			if( ! isset( $args['id'] ) ) {
+				return;
+			}
+
 			$notice_id = $args['id']; // Notice ID.
 			$notices = get_option( 'allowed_astra_notices', array() );
 			if(array_search($notice_id, $notices) === false) { 
@@ -135,8 +137,8 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 				'session_tokens',
 			);
 
-			// Verify that the notice being dismissed is in the list of allowed notices.
-			if(array_search($notice_id, $allowed_notices) === false) { 
+			// if $notice_id does not start with astra-notices-id and notice_id is not from the allowed notices, then return.
+			if ( strpos( $notice_id, 'astra-notices-id-' ) === false && array_search( $notice_id, $allowed_notices ) === false ) {
 				return;
 			}
 


### PR DESCRIPTION
This pull request includes updates to the `class-astra-notices.php` file to improve versioning and add validation for notice IDs. The most important changes are as follows:

Versioning Update:
* Updated the `Astra_Notices` class version from '1.1.12' to '1.1.13'.

Validation Improvement:
* Added a check to ensure that the `id` field is not empty before proceeding with adding a notice in the `add_notice` method.