### PR TITLE
Fix esc_html_e() void return breaking wp_send_json_error() responses

### DIFF
--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -143,14 +143,14 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 			}
 
 			if ( false === wp_verify_nonce( $nonce, 'astra-notices' ) ) {
-				wp_send_json_error( esc_html_e( 'WordPress Nonce not validated.' ) );
+				wp_send_json_error( esc_html__( 'WordPress Nonce not validated.', 'astra-notices' ) );
 			}
 
 			// Valid inputs?
 			if ( ! empty( $notice_id ) ) {
 
 				if ( in_array( $notice_id, $wp_default_meta_keys, true ) ) {
-					wp_send_json_error( esc_html_e( 'Invalid notice ID.' ) );
+					wp_send_json_error( esc_html__( 'Invalid notice ID.', 'astra-notices' ) );
 				}
 
 				if ( ! empty( $repeat_notice_after ) ) {


### PR DESCRIPTION
## Summary

- Replaced `esc_html_e()` with `esc_html__()` in both error responses inside `dismiss_notice()`
- `esc_html_e()` echoes directly and returns `void`; passing it to `wp_send_json_error()` silently sends `null` as the error message instead of the intended string
- `esc_html__()` returns the escaped, translated string — the correct function for this context
- Added missing `'astra-notices'` text domain to both calls for proper i18n

Fixes #72

## Test plan

- [ ] Trigger the nonce validation failure path in `dismiss_notice()` and verify the JSON error response contains `"WordPress Nonce not validated."`
- [ ] Trigger the invalid notice ID path and verify the JSON error response contains `"Invalid notice ID."`
- [ ] Confirm no PHP warnings or notices are produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)