### PR TITLE
Fix: scope transient keys to current user (issue #75)

### DIFF
--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -154,7 +154,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 				}
 
 				if ( ! empty( $repeat_notice_after ) ) {
-					set_transient( $notice_id, true, $repeat_notice_after );
+					set_transient( $notice_id . '_' . get_current_user_id(), true, $repeat_notice_after );
 				} else {
 					update_user_meta( get_current_user_id(), $notice_id, 'notice-dismissed' );
 				}
@@ -369,7 +369,8 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @return boolean
 		 */
 		private static function is_expired( $notice ) {
-			$transient_status = get_transient( $notice['id'] );
+			$transient_key    = $notice['id'] . '_' . get_current_user_id();
+			$transient_status = get_transient( $transient_key );
 
 			if ( false === $transient_status ) {
 
@@ -377,7 +378,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 
 					if ( 'delayed-notice' !== get_user_meta( get_current_user_id(), $notice['id'], true ) &&
 						'notice-dismissed' !== get_user_meta( get_current_user_id(), $notice['id'], true ) ) {
-						set_transient( $notice['id'], 'delayed-notice', $notice['display-notice-after'] );
+						set_transient( $transient_key, 'delayed-notice', $notice['display-notice-after'] );
 						update_user_meta( get_current_user_id(), $notice['id'], 'delayed-notice' );
 
 						return false;


### PR DESCRIPTION
## Summary

- `set_transient()` and `get_transient()` were using bare notice IDs as cache keys, making dismissal state site-wide
- One admin dismissing a repeating notice suppressed it for **all** users
- All three transient operations now append `'_' . get_current_user_id()` to the key so each user's dismissal and delay state is stored independently

**Changed locations in `class-astra-notices.php`:**
- `dismiss_notice()` line 157 — repeat-dismissal write
- `is_expired()` line 372 — read (introduced `$transient_key` variable)
- `is_expired()` line 381 — delayed-display write (reuses `$transient_key`)

Permanent dismissals already use `update_user_meta()` / `get_user_meta()` and are unaffected.

Closes #75

## Test plan

- [ ] Log in as User A, dismiss a repeating notice → notice disappears for User A
- [ ] Log in as User B → notice is still visible (not suppressed by User A's dismissal)
- [ ] After the repeat interval expires for User A, the notice reappears for User A only
- [ ] Delayed notices (`display-notice-after`) similarly respect per-user timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)