### PR TITLE
fix: add nonce verification for notice dismissal

### DIFF
--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -116,9 +116,10 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @return void
 		 */
 		public function dismiss_notice() {
+			check_ajax_referer( 'astra-notices', 'nonce' );
+
 			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( $_POST['notice_id'] ) : '';
 			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( $_POST['repeat_notice_after'] ) : '';
-			$nonce               = ( isset( $_POST['nonce'] ) ) ? sanitize_key( $_POST['nonce'] ) : '';
 			$notice              = $this->get_notice_by_id( $notice_id );
 			$capability          = isset( $notice['capability'] ) ? $notice['capability'] : 'manage_options';
 
@@ -140,10 +141,6 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 			// if $notice_id does not start with astra-notices-id and notice_id is not from the allowed notices, then return.
 			if ( strpos( $notice_id, 'astra-notices-id-' ) !== 0 && ( ! in_array( $notice_id, $allowed_notices, true ) ) ) {
 				return;
-			}
-
-			if ( false === wp_verify_nonce( $nonce, 'astra-notices' ) ) {
-				wp_send_json_error( esc_html_e( 'WordPress Nonce not validated.' ) );
 			}
 
 			// Valid inputs?

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @var array Notices.
 		 * @since 1.0.0
 		 */
-		private static $version = '1.1.14';
+		private static $version = '1.1.15';
 
 		/**
 		 * Notices


### PR DESCRIPTION
## Summary

- Move `check_ajax_referer()` to the very top of `dismiss_notice()` so the nonce is verified **before** any `$_POST` data is read or processed
- Remove the redundant `$nonce` variable and the late `wp_verify_nonce()` check that occurred after `$_POST` data was already consumed
- Addresses WP.org plugin review feedback: AJAX handlers must verify nonces before processing input

## Details

The JS side (`notices.js`) already sends `nonce: astraNotices._notice_nonce` in the AJAX payload, and the PHP enqueue (`enqueue_scripts()`) already creates the nonce via `wp_create_nonce('astra-notices')`. The existing `wp_verify_nonce()` call was positioned too late — after `$_POST` values were read, database queries were executed (`get_notice_by_id`), and capability checks were performed.

`check_ajax_referer('astra-notices', 'nonce')` replaces this with the WordPress-recommended pattern: it validates the nonce from `$_REQUEST['nonce']` against the `astra-notices` action and calls `wp_die()` on failure, ensuring no further code executes without a valid nonce.

## Test plan

- [ ] Verify admin notices display correctly on the dashboard
- [ ] Dismiss a notice and confirm it stays dismissed (AJAX call succeeds with valid nonce)
- [ ] Verify that an AJAX request without a valid nonce returns a `wp_die()` response (403)


🤖 Generated with [Claude Code](https://claude.com/claude-code)