### PR TITLE
fix: add wp_unslash() for WordPress.org compliance

### DIFF
--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -118,8 +118,8 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		public function dismiss_notice() {
 			check_ajax_referer( 'astra-notices', 'nonce' );
 
-			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( $_POST['notice_id'] ) : '';
-			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( $_POST['repeat_notice_after'] ) : '';
+			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( wp_unslash( $_POST['notice_id'] ) ) : '';
+			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( wp_unslash( $_POST['repeat_notice_after'] ) ) : '';
 			$notice              = $this->get_notice_by_id( $notice_id );
 			$capability          = isset( $notice['capability'] ) ? $notice['capability'] : 'manage_options';
 


### PR DESCRIPTION
## Summary
- Wrap `$_POST` superglobal reads with `wp_unslash()` before sanitization functions

## Context
WordPress.org plugin review requires `wp_unslash()` on all superglobal access.

## Files changed
- `class-astra-notices.php`

## Test plan
- [ ] Admin notices display and dismiss correctly
- [ ] No PHPCS `WordPress.Security.ValidatedSanitizedInput` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)