### PR TITLE
fix: WordPress.org plugin review compliance fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,7 +56,7 @@ add_action(
 					$image_path,
 					__( 'Hello! Seems like you have used Header Footer Elementor to build this website — Thanks a ton!', 'header-footer-elementor' ),
 					__( 'Could you please do us a BIG favor and give it a 5-star rating on WordPress? This would boost our motivation and help other users make a comfortable decision while choosing the Header Footer Elementor.', 'header-footer-elementor' ),
-					'https://wordpress.org/support/plugin/header-footer-elementor/reviews/?filter=5#new-post',
+					'https://wordpress.org/support/plugin/header-footer-elementor/reviews/#new-post',
 					__( 'Ok, you deserve it', 'header-footer-elementor' ),
 					MONTH_IN_SECONDS,
 					__( 'Nope, maybe later', 'header-footer-elementor' ),


### PR DESCRIPTION
## Summary

Fixes the **critical** 5-star review link issue (#79) reported during the WordPress.org plugin review for **Spectra Blocks**.

Review ID: `R spectra-blocks/brainstormforce/27Feb26/T3 18Mar26/3.8`

### Fix

**#79 — Remove 5-star filter from review URL in README**
- Removed `?filter=5` from the example review URL in `README.MD:59`
- Changed: `reviews/?filter=5#new-post` → `reviews/#new-post`

> **CRITICAL:** The reviewer flagged this in round 1 AND explicitly called it out as NOT fixed in round 2:
> _"The link to the reviews on the readme.md file (inside lib/astra/notices) still links to the review filtered to show only the 5 stars reviews."_

### Not included (by design)

**#80 (hook renames)** and **#81 (option rename)** are NOT included in this PR because:
- The `astra` prefix is 5 characters — already meets the 4+ character requirement
- Renaming hooks (`astra_notice_*` → `astra_notices_*`) would break the Astra theme and all BSF plugins that hook into these
- Renaming the option (`allowed_astra_notices`) would cause dismissed notices to reappear for all existing users
- These are backward-incompatible changes that need a separate discussion with the team

The reviewer listed these in their prefix analysis but `astra` (5 chars) is a valid prefix. We can discuss #80/#81 separately if the reviewer explicitly requires it after resubmission.

### Test plan

- [ ] Verify `README.MD` review URL no longer has `?filter=5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)