### PR TITLE
fix: add wp_unslash() before sanitization on $_POST access

### DIFF
--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		 * @var array Notices.
 		 * @since 1.0.0
 		 */
-		private static $version = '1.1.15';
+		private static $version = '1.1.16';
 
 		/**
 		 * Notices

--- a/class-astra-notices.php
+++ b/class-astra-notices.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'Astra_Notices' ) ) :
 		public function dismiss_notice() {
 			check_ajax_referer( 'astra-notices', 'nonce' );
 
-			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( $_POST['notice_id'] ) : '';
+			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( wp_unslash( $_POST['notice_id'] ) ) : '';
 			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( $_POST['repeat_notice_after'] ) : '';
 			$notice              = $this->get_notice_by_id( $notice_id );
 			$capability          = isset( $notice['capability'] ) ? $notice['capability'] : 'manage_options';


### PR DESCRIPTION
## Summary
- Added `wp_unslash()` before `sanitize_key()` on `$_POST['notice_id']` in `dismiss_notice()` method
- Required by WordPress.org plugin review for spectra-blocks submission

## Test plan
- [ ] Dismiss a notice in WP admin and verify it stays dismissed
- [ ] No PHP errors with WP_DEBUG enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)