### PR TITLE
fix: rename allowed_astra_notices option to astra_notices_allowed

### DIFF
--- a/class-bsf-admin-notices.php
+++ b/class-bsf-admin-notices.php
@@ -139,7 +139,7 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 			check_ajax_referer( 'astra-notices', 'nonce' );
 
 			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( wp_unslash( $_POST['notice_id'] ) ) : '';
-			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( $_POST['repeat_notice_after'] ) : 0;
+			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( wp_unslash( $_POST['repeat_notice_after'] ) ) : 0;
 			$notice              = $this->get_notice_by_id( $notice_id );
 			$capability          = isset( $notice['capability'] ) ? $notice['capability'] : 'manage_options';
 

--- a/class-bsf-admin-notices.php
+++ b/class-bsf-admin-notices.php
@@ -82,7 +82,7 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 		/**
 		 * Migrate allowed_astra_notices → astra_notices_allowed (one-time, on first load).
 		 *
-		 * @since x.x.x
+		 * @since 1.2.2
 		 * @return void
 		 */
 		private function maybe_migrate_notices_option() {

--- a/class-bsf-admin-notices.php
+++ b/class-bsf-admin-notices.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 		 * @var string
 		 * @since 1.2.0
 		 */
-		private static $version = '1.2.1';
+		private static $version = '1.2.2';
 
 		/**
 		 * Registered notices.
@@ -72,10 +72,25 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 		 * @since 1.2.0
 		 */
 		public function __construct() {
+			$this->maybe_migrate_notices_option();
 			add_action( 'admin_notices', array( $this, 'show_notices' ), 30 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'wp_ajax_astra-notice-dismiss', array( $this, 'dismiss_notice' ) );
 			add_filter( 'wp_kses_allowed_html', array( $this, 'add_data_attributes' ), 10, 2 );
+		}
+
+		/**
+		 * Migrate allowed_astra_notices → astra_notices_allowed (one-time, on first load).
+		 *
+		 * @since x.x.x
+		 * @return void
+		 */
+		private function maybe_migrate_notices_option() {
+			$old = get_option( 'allowed_astra_notices', false );
+			if ( false !== $old ) {
+				update_option( 'astra_notices_allowed', $old );
+				delete_option( 'allowed_astra_notices' );
+			}
 		}
 
 		/**
@@ -107,10 +122,10 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 			}
 
 			$notice_id = sanitize_key( $args['id'] ); // Notice ID.
-			$notices   = get_option( 'allowed_astra_notices', array() );
+			$notices   = get_option( 'astra_notices_allowed', array() );
 			if ( ! in_array( $notice_id, $notices, true ) ) {
 				$notices[] = $notice_id; // Add notice id to the array.
-				update_option( 'allowed_astra_notices', $notices ); // Update the option.
+				update_option( 'astra_notices_allowed', $notices ); // Update the option.
 			}
 		}
 
@@ -144,7 +159,7 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 				wp_send_json_error( esc_html__( 'Permission denied.', 'astra-notices' ) );
 			}
 
-			$allowed_notices = get_option( 'allowed_astra_notices', array() ); // Get allowed notices.
+			$allowed_notices = get_option( 'astra_notices_allowed', array() ); // Get allowed notices.
 
 			// Define restricted user meta keys using the dynamic table prefix.
 			global $wpdb;


### PR DESCRIPTION
## Summary

- WordPress.org review (Round T9) flagged `allowed_astra_notices` as using a short non-specific prefix (`allowed_`).
- Renamed the option to `astra_notices_allowed` which uses the full `astra_notices_` library prefix.
- Added `maybe_migrate_notices_option()` called in `__construct()` — runs once on first load to carry over existing values from the old option key, then deletes it.
- Bumped version 1.2.1 → 1.2.2.

**File changed:** `class-bsf-admin-notices.php`

## Coordination required before merging

`allowed_astra_notices` is also written by **Astra theme** and **Starter Templates**. All products must ship this migration simultaneously (or within the same release cycle) to avoid the old option being re-created after migration. Please coordinate with the Astra theme and Starter Templates teams before merging and tagging.

## Test plan

- [ ] On a fresh site: verify notices show and dismiss correctly using the new `astra_notices_allowed` option
- [ ] On a site with existing `allowed_astra_notices` data: verify migration runs once, carries values to `astra_notices_allowed`, deletes the old key
- [ ] Verify `allowed_astra_notices` does not reappear after the migration (i.e. no other active product writes the old key in your test env)
- [ ] Run PHPCS — confirm no prefix warnings