### PR TITLE
fix: add wp_unslash() before absint() on repeat_notice_after (wp.org compliance)

### DIFF
--- a/class-bsf-admin-notices.php
+++ b/class-bsf-admin-notices.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 			check_ajax_referer( 'astra-notices', 'nonce' );
 
 			$notice_id           = ( isset( $_POST['notice_id'] ) ) ? sanitize_key( wp_unslash( $_POST['notice_id'] ) ) : '';
-			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( $_POST['repeat_notice_after'] ) : 0;
+			$repeat_notice_after = ( isset( $_POST['repeat_notice_after'] ) ) ? absint( wp_unslash( $_POST['repeat_notice_after'] ) ) : 0;
 			$notice              = $this->get_notice_by_id( $notice_id );
 			$capability          = isset( $notice['capability'] ) ? $notice['capability'] : 'manage_options';
 


### PR DESCRIPTION
## Summary

- Adds `wp_unslash()` before `absint()` on the `$_POST['repeat_notice_after']` field in `dismiss_notice()` (`class-bsf-admin-notices.php:127`)
- WPCS `ValidatedSanitizedInput` requires `wp_unslash()` before any sanitizer on superglobal values

## Context

Flagged during independent compliance audit for the wp.org T9 review round of `spectra-blocks` (Review ID: `R spectra-blocks/brainstormforce/17May26/T1 17May26/4.0`).

## Functional impact

Zero. `wp_unslash()` strips magic-quote backslashes; on a numeric string (repeat interval in seconds) it is a complete no-op. `absint()` still produces the same non-negative integer.

## Test plan

- [ ] Dismissing an admin notice with a repeat interval still sets the transient correctly
- [ ] Dismissing a permanent notice (no repeat) still works
- [ ] PHPCS passes on `class-bsf-admin-notices.php`