### PR TITLE
fix: wp.org compliance — implicit global and handle collision in astra-notices

### DIFF
--- a/class-bsf-admin-notices.php
+++ b/class-bsf-admin-notices.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 		 * @var string
 		 * @since 1.2.0
 		 */
-		private static $version = '1.2.2';
+		private static $version = '1.2.3';
 
 		/**
 		 * Registered notices.

--- a/class-bsf-admin-notices.php
+++ b/class-bsf-admin-notices.php
@@ -202,11 +202,11 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 		 * @return void
 		 */
 		public function enqueue_scripts() {
-			wp_register_style( 'astra-notices', self::get_url() . 'notices.css', array(), self::$version );
-			wp_register_script( 'astra-notices', self::get_url() . 'notices.js', array( 'jquery' ), self::$version, true );
+			wp_register_style( 'bsf-astra-notices', self::get_url() . 'notices.css', array(), self::$version );
+			wp_register_script( 'bsf-astra-notices', self::get_url() . 'notices.js', array( 'jquery' ), self::$version, true );
 			wp_localize_script(
-				'astra-notices',
-				'astraNotices',
+				'bsf-astra-notices',
+				'bsfAstraNotices',
 				array(
 					'_notice_nonce' => wp_create_nonce( 'astra-notices' ),
 				)
@@ -328,8 +328,8 @@ if ( ! class_exists( 'BSF_Admin_Notices' ) ) :
 		 * @return void
 		 */
 		public static function markup( $notice = array() ) {
-			wp_enqueue_script( 'astra-notices' );
-			wp_enqueue_style( 'astra-notices' );
+			wp_enqueue_script( 'bsf-astra-notices' );
+			wp_enqueue_style( 'bsf-astra-notices' );
 
 			// Dual-emit: legacy (astra_notice_*) + new (bsf_admin_notice_*) hooks for backward compat.
 			// Note: consumers hooking BOTH names for the same event will be called twice.

--- a/notices.js
+++ b/notices.js
@@ -12,7 +12,7 @@
 	 * @since 1.0.0
 	 * @class ASTCustomizer
 	 */
-	AstraNotices = {
+	var AstraNotices = {
 
 		/**
 		 * Initializes our custom logic for the Customizer.
@@ -80,7 +80,7 @@
 				type: 'POST',
 				data: {
 					action            : 'astra-notice-dismiss',
-					nonce             : astraNotices._notice_nonce,
+					nonce             : bsfAstraNotices._notice_nonce,
 					notice_id         : notice_id,
 					repeat_notice_after : parseInt( repeat_notice_after, 10 ),
 				},


### PR DESCRIPTION
## Summary
- **Fix 1 — Implicit global (notices.js):** Added `var` declaration to `AstraNotices = {` → `var AstraNotices = {`. Without it the variable leaked into the global scope, which wp.org flags as a rejection-level issue.
- **Fix 2 — Script/style handle collision (class-bsf-admin-notices.php):** Renamed all `wp_register_script`, `wp_register_style`, `wp_enqueue_script`, `wp_enqueue_style` handles from `astra-notices` to `bsf-astra-notices`. Generic handles like `astra-notices` collide with other plugins using the same name.
- **Fix 3 — Localized JS global renamed (class-bsf-admin-notices.php + notices.js):** Renamed `wp_localize_script` object from `astraNotices` → `bsfAstraNotices` and updated `notices.js` to reference `bsfAstraNotices._notice_nonce`. Unprefixed globals are flagged by wp.org review.
- **Frozen (backward-compat):** AJAX action `astra-notice-dismiss`, nonce `astra-notices`, CSS classes, option keys, and user meta keys are all unchanged.
- Required for `spectra-blocks` wp.org submission — this library is bundled and must pass wp.org review.

## Test plan
- [ ] Verify admin notices render correctly on a test WordPress site
- [ ] Dismiss a notice — confirm AJAX fires with action `astra-notice-dismiss` (Network tab) and nonce is present
- [ ] Confirm notice stays dismissed after page reload (user meta persists)
- [ ] Confirm no JS console errors on admin pages
- [ ] Confirm no handle collision warnings in `wp_register_script` (test alongside a plugin that uses `astra-notices` handle)
- [ ] Run `phpcs --standard=phpcs.xml.dist class-bsf-admin-notices.php` — no new violations
- [ ] Test with `spectra-blocks` bundling this lib and confirm wp.org scanner no longer flags the implicit global or handle